### PR TITLE
Use external FEC header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,6 +779,14 @@ set (SRT_SRC_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common)
 set (SRT_SRC_TOOLS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools)
 set (SRT_SRC_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
 
+# Locate external FEC header
+find_path(FEC_INCLUDE_DIR fec.h HINTS ${SRT_SRC_SRTCORE_DIR})
+if (FEC_INCLUDE_DIR)
+    message(STATUS "FEC include dir: ${FEC_INCLUDE_DIR}")
+else()
+    message(FATAL_ERROR "Failed to find fec.h. Specify FEC_INCLUDE_DIR.")
+endif()
+
 if(WIN32)
 	message(STATUS "DETECTED SYSTEM: WINDOWS;  WIN32=1; PTW32_STATIC_LIB=1")
 	add_definitions(-DWIN32=1 -DPTW32_STATIC_LIB=1)
@@ -823,6 +831,7 @@ endif()
 
 # This is obligatory include directory for all targets. This is only
 # for private headers. Installable headers should be exclusively used DIRECTLY.
+include_directories(${FEC_INCLUDE_DIR})
 include_directories(${SRT_SRC_COMMON_DIR} ${SRT_SRC_SRTCORE_DIR} ${SRT_SRC_HAICRYPT_DIR})
 
 if (ENABLE_LOGGING)

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -21,7 +21,7 @@
 #include "packet.h"
 #include "logging.h"
 
-#include "fec.h"
+#include <fec.h>
 
 // Maximum allowed "history" remembered in the receiver groups.
 // This is calculated in series, that is, this number will be

--- a/srtcore/packetfilter_builtin.h
+++ b/srtcore/packetfilter_builtin.h
@@ -13,6 +13,6 @@
 #define INC_SRT_PACKETFILTER_BUILTIN_H
 
 // Integration header
-#include "fec.h"
+#include <fec.h>
 
 #endif

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -5,7 +5,7 @@
 #include "gtest/gtest.h"
 #include "test_env.h"
 #include "packet.h"
-#include "fec.h"
+#include <fec.h>
 #include "core.h"
 #include "packetfilter.h"
 #include "packetfilter_api.h"


### PR DESCRIPTION
## Summary
- include `<fec.h>` in FEC-related sources
- find and require `fec.h` via CMake

## Testing
- `cmake -S . -B build`

------
https://chatgpt.com/codex/tasks/task_e_684b11a85b9c83239189d5bebb728d4e