### PR TITLE
Fix rsfec parity headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@
 | [SRT Handshake](features/handshake.md)                       |     [features](features/)     | [handshake.md](features/handshake.md)                        | Description of SRT handshake mechanism. This<br />document might be outdated, please consult<br />[Section 3.2.1 Handshake][srt-internet-draft-sec-3-2-1] and<br />[Section 4.3 Handshake Messages](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-4.3) of the<br />[Internet Draft][srt-internet-draft] additionally. |
 | [Live Streaming <br /> Guidelines](features/live-streaming.md) |   [features](features/)     | [live-streaming.md](features/live-streaming.md)              | Guidelines for live streaming with SRT. See also<br />best practices and configuration tips in<br />[Section 7.1 Live Streaming](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-7.1) of the [Internet Draft][srt-internet-draft]. |
 | [SRT Packet <br /> Filtering & FEC][packet-filter]           |     [features](features/)     | [packet-filtering-and-fec.md][packet-filter]                 | Description of SRT packet filtering mechanism,<br />including FEC. |
+| [Reed-Solomon FEC Filter](features/rsfec.md)                 |     [features](features/)     | [rsfec.md](features/rsfec.md)                                | Alternative FEC filter based on Reed-Solomon coding. |
 | <img width=200px height=1px/>                                | <img width=100px height=1px/> | <img width=200px height=1px/>                                | <img width=500px height=1px/>                                |
 
 ## Sample Applications
@@ -75,3 +76,4 @@
 
 [main-backup]: features/bonding-main-backup.md
 [packet-filter]: features/packet-filtering-and-fec.md
+[rsfec]: features/rsfec.md

--- a/docs/features/packet-filtering-and-fec.md
+++ b/docs/features/packet-filtering-and-fec.md
@@ -27,7 +27,8 @@ filtering, was originally created as a means to implement Forward Error
 Correction (FEC) in SRT, but can be extended for other uses.
 
 As of SRT version 1.4 there is one built-in filter ("fec") installed, but more
-can be added.
+can be added. The source tree also contains an experimental Reed‑Solomon filter
+named `rsfec` which follows the same configuration principles.
 
 # Configuration
 

--- a/docs/features/rsfec.md
+++ b/docs/features/rsfec.md
@@ -1,0 +1,15 @@
+# Reed-Solomon FEC Filter
+
+The `rsfec` packet filter implements forward error correction based on the Reed-Solomon algorithm. It is compiled with the library and can be enabled with the `packetfilter` URI parameter or by setting the `SRTO_PACKETFILTER` socket option.
+
+## Configuration
+
+Specify the number of data packets `k` and parity packets `parity` that form one FEC block. For example:
+
+```
+srt://receiver:5000?latency=500&packetfilter=rsfec,k:10,parity:2
+```
+
+Both peers must use the same configuration. The receiver only needs to specify the filter type (for example `packetfilter=rsfec`) if the sender provides the full set of parameters.
+
+The latency must be large enough to cover the time required to transmit all packets of a block. See [SRT Packet Filtering & FEC](packet-filtering-and-fec.md) for details about computing the required latency.

--- a/srtcore/rsfec.cpp
+++ b/srtcore/rsfec.cpp
@@ -103,6 +103,11 @@ bool RSFecFilter::packControlPacket(SrtPacket& pkt, int32_t seq)
         return false;
     }
     pkt = snd.parity[snd.next_parity++];
+    // mark as filter control packet in case the caller bypasses the
+    // PacketFilter wrapper
+    pkt.hdr[SRT_PH_MSGNO] = SRT_MSGNO_CONTROL |
+        MSGNO_PACKET_BOUNDARY::wrap(PB_SOLO);
+    pkt.hdr[SRT_PH_ID] = socketID();
     return true;
 }
 


### PR DESCRIPTION
## Summary
- mark parity packets as control so receivers don't mistake them for data

## Testing
- `cmake .. -DENABLE_UNITTESTS=OFF -DENABLE_TESTING=OFF`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684d37917a8883238a42eb3e9778db04