### PR TITLE
Fix initializer order in RSFecFilter

### DIFF
--- a/srtcore/rsfec.cpp
+++ b/srtcore/rsfec.cpp
@@ -44,10 +44,10 @@ RSFecFilter::RSFecFilter(const SrtFilterInitializer& init, vector<SrtPacket>& pr
                          const string& confstr)
     : SrtPacketFilterBase(init)
     , m_rs(nullptr)
+    , m_timeout_us(0)
     , snd()
     , rcv_base(CSeqNo::incseq(rcvISN()))
     , m_provided(provided)
-    , m_timeout_us(0)
 {
     if (!ParseFilterConfig(confstr, cfg))
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);


### PR DESCRIPTION
## Summary
- fix `RSFecFilter` member initialization order to silence `-Wreorder`

## Testing
- `cmake .. -DENABLE_UNITTESTS=ON`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684dda6890288323839cf3e564313fd0