### PR TITLE
Document building SRT with RSFEC

### DIFF
--- a/docs/build/build-linux.md
+++ b/docs/build/build-linux.md
@@ -18,7 +18,8 @@ Here is a link to a demo showing how CMake can be used to build SRT:
 ```shell
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install tclsh pkg-config cmake libssl-dev build-essential
+sudo apt-get install tclsh pkg-config cmake libssl-dev build-essential \
+    libfec-dev libfec0
 ./configure
 make
 ```

--- a/docs/build/build-options.md
+++ b/docs/build/build-options.md
@@ -29,6 +29,8 @@ Option details are given further below.
 | [`CYGWIN_USE_POSIX`](#cygwin_use_posix)                      | 1.2.0 | `BOOL`    | OFF        | Determines when to compile on Cygwin using POSIX API.                                                                                                |
 | [`ENABLE_APPS`](#enable_apps)                                | 1.3.3 | `BOOL`    | ON         | Enables compiling sample applications (`srt-live-transmit`, etc.).                                                                                   |
 | [`ENABLE_BONDING`](#enable_bonding)                          | 1.5.0 | `BOOL`    | OFF        | Enables the [Connection Bonding](../features/bonding-quick-start.md) feature.                                                                        |
+| [`ENABLE_RSFEC`](#enable_rsfec)                              | 1.6.0 | `BOOL`    | ON         | Enables the Reed-Solomon packet filter when `libfec` is available.
+|       |
 | [`ENABLE_CXX_DEPS`](#enable_cxx_deps)                        | 1.3.2 | `BOOL`    | OFF        | The `pkg-confg` file (`srt.pc`) will be generated with the `libstdc++` library as a dependency.                                                      |
 | [`ENABLE_CXX11`](#enable_cxx11)                              | 1.2.0 | `BOOL`    | ON         | Enable compiling in C++11 mode for those parts that may require it. Default: ON except for GCC<4.7                                                   |
 | [`ENABLE_CODE_COVERAGE`](#enable_code_coverage)              | 1.4.0 | `BOOL`    | OFF        | Enables instrumentation for code coverage.                                                                                                           |
@@ -205,6 +207,18 @@ Two modes are supported:
 - [Main/Backup](../features/bonding-main-backup.md) - In *Main/Backup* mode, only one (main) link at a time is used for data transmission while other (backup) connections are on standby to ensure the transmission will continue if the main link fails. The goal of Main/Backup mode is to identify a potential link break before it happens, thus providing a time window within which to seamlessly switch to one of the backup links.
 
 With the Connection Bonding feature disabled, [bonding API functions](../API/API-functions.md#socket-group-management) are present, but return an error.
+
+[:arrow_up: &nbsp; Back to List of Build Options](#list-of-build-options)
+
+
+#### ENABLE_RSFEC
+**`--enable-rsfec`** (default: ON)
+
+Build the experimental Reed-Solomon packet filter. This requires the
+[libfec](https://github.com/quiet/libfec) development package. When enabled the
+library can transparently encode and decode parity packets by specifying
+`packetfilter=rsfec` or using the `SRTO_PACKETFILTER` socket option.
+
 
 
 #### ENABLE_CXX_DEPS

--- a/docs/features/rsfec.md
+++ b/docs/features/rsfec.md
@@ -17,3 +17,17 @@ The latency must be large enough to cover the time required to transmit all pack
 ## Additional parameters
 
 `timeout` sets a timeout in milliseconds for completing a block. If fewer than `k` packets arrive within this time, the partial block is flushed without parity. Default is `0` (disabled).
+
+## Building
+
+Support for the `rsfec` packet filter is compiled into the library when the
+[libfec](https://github.com/quiet/libfec) development files are available.
+On Debian and Ubuntu based systems install them with:
+
+```shell
+sudo apt install libfec-dev libfec0
+```
+
+`cmake` or the `configure` script will automatically enable `ENABLE_RSFEC` when
+`libfec` is found. If the library is missing the packet filter is disabled and
+peers using it will not interoperate correctly.


### PR DESCRIPTION
## Summary
- add Ubuntu `libfec` packages to Linux build instructions
- explain how to compile RSFEC support
- document `ENABLE_RSFEC` build option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ddd79c6008323b8b817b76d8d0dfe