### PR TITLE
Fix srt-live-transmit payload size override and silence FEC RS warning

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -193,7 +193,8 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
     // That's kinda clumsy, but it must rely on the defaults.
     // Default mode is live, so check if the file mode was enforced
     if ((par.count("transtype") == 0 || par["transtype"] != "file")
-        && transmit_chunk_size > SRT_LIVE_DEF_PLSIZE)
+        && transmit_chunk_size > SRT_LIVE_DEF_PLSIZE
+        && par.count("payloadsize") == 0)
     {
         if (transmit_chunk_size > SRT_LIVE_MAX_PLSIZE)
             throw std::runtime_error("Chunk size in live mode exceeds 1456 bytes; this is not supported");

--- a/srtcore/fec_rs.cpp
+++ b/srtcore/fec_rs.cpp
@@ -188,6 +188,7 @@ void FECFilterRS::attemptDecode(RecvGroup& g)
 
 bool FECFilterRS::receive(const CPacket& pkt, loss_seqs_t& loss)
 {
+    (void)loss;
     if (pkt.getMsgSeq() == SRT_MSGNO_CONTROL) {
         const unsigned char* p = (const unsigned char*)pkt.data();
         unsigned idx = p[0];


### PR DESCRIPTION
## Summary
- avoid compiler warning in FECFilterRS by marking `loss` as unused
- don't overwrite user-provided payloadsize in srt-live-transmit when chunk size is set

## Testing
- `./scripts/check-deps`
- `./configure`
- `make -j2` *(fails: fatal error: /usr/include/fec.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4e003d48323bc52fa2891c129e8