### PR TITLE
Fix FEC filter warnings and runtime payload issue

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -434,6 +434,17 @@ void SrtCommon::ConnectClient(string host, int port)
     stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
         Error("ConfigurePost");
+
+    if (m_output_direction)
+    {
+        int payload = 0;
+        int optlen = sizeof payload;
+        if (srt_getsockopt(m_sock, 0, SRTO_PAYLOADSIZE, &payload, &optlen) == 0 && payload > 0)
+        {
+            if ((unsigned long)payload < transmit_chunk_size)
+                transmit_chunk_size = payload;
+        }
+    }
 }
 
 void SrtCommon::Error(string src)

--- a/srtcore/fec_rs.cpp
+++ b/srtcore/fec_rs.cpp
@@ -37,6 +37,7 @@ bool FECFilterRS::verifyConfig(const SrtFilterConfig& cfg, string& err)
 FECFilterRS::FECFilterRS(const SrtFilterInitializer& init, std::vector<SrtPacket>& provided, const string& conf)
     : SrtPacketFilterBase(init)
 {
+    (void)provided;
     SrtFilterConfig cfg;
     ParseFilterConfig(conf, cfg);
     m_cols      = atoi(map_get(cfg.parameters, "cols").c_str());

--- a/srtcore/rs/fec.cpp
+++ b/srtcore/rs/fec.cpp
@@ -795,6 +795,7 @@ shuffle(gf *pkt[], int index[], int k)
 static gf *
 build_decode_matrix(struct fec_parms *code, gf *pkt[], int index[])
 {
+    (void)pkt;
     int i , k = code->k ;
     gf *p, *matrix = NEW_GF_MATRIX(k, k);
 


### PR DESCRIPTION
## Summary
- silence unused variable warnings in FEC code
- adjust output chunk size when SRT target connects to honor negotiated payload size

## Testing
- `./configure`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68503756f80083239f7ad0980c3e1843