### PR TITLE
Add reedsolomon packet filter skeleton

### DIFF
--- a/srtcore/fec_rs.cpp
+++ b/srtcore/fec_rs.cpp
@@ -1,0 +1,94 @@
+#include "platform_sys.h"
+
+#include <string>
+#include <vector>
+
+#include "packetfilter.h"
+#include "core.h"
+#include "packet.h"
+#include "logging.h"
+#include "fec_rs.h"
+
+using namespace std;
+using namespace srt_logging;
+
+namespace srt {
+
+const char FECReedSolomon::defaultConfig[] = "rsfec,cols:4,rows:2";
+
+bool FECReedSolomon::verifyConfig(const SrtFilterConfig& cfg, string& w_error)
+{
+    string cols = map_get(cfg.parameters, "cols");
+    if (cols.empty()) {
+        w_error = "parameter 'cols' is mandatory";
+        return false;
+    }
+    int c = atoi(cols.c_str());
+    if (c < 1) {
+        w_error = "'cols' must be > 0";
+        return false;
+    }
+    string rows = map_get(cfg.parameters, "rows");
+    if (!rows.empty()) {
+        int r = atoi(rows.c_str());
+        if (r < 1) {
+            w_error = "'rows' must be > 0";
+            return false;
+        }
+    }
+    return true;
+}
+
+FECReedSolomon::FECReedSolomon(const SrtFilterInitializer& init,
+                               vector<SrtPacket>& provided,
+                               const string& conf)
+    : SrtPacketFilterBase(init),
+      rs(NULL),
+      data_shards(0),
+      parity_shards(0),
+      provided_packets(provided)
+{
+    if (!ParseFilterConfig(conf, cfg))
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+
+    string emsg;
+    if (!verifyConfig(cfg, emsg))
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+
+    data_shards = atoi(cfg.parameters["cols"].c_str());
+    parity_shards = atoi(map_get(cfg.parameters, "rows").c_str());
+    if (parity_shards == 0)
+        parity_shards = 1;
+
+    rs = init_rs_char(8, 0x11d, 0, 1, parity_shards, 0);
+}
+
+FECReedSolomon::~FECReedSolomon()
+{
+    if (rs)
+        free_rs_char(rs);
+}
+
+bool FECReedSolomon::packControlPacket(SrtPacket& pkt, int32_t seq)
+{
+    (void)pkt;
+    (void)seq;
+    // TODO: generate parity packet using encode_rs_char
+    return false;
+}
+
+void FECReedSolomon::feedSource(CPacket& pkt)
+{
+    // TODO: collect packets and prepare parity data
+    (void)pkt;
+}
+
+bool FECReedSolomon::receive(const CPacket& pkt, loss_seqs_t& loss_seqs)
+{
+    // TODO: decode parity and rebuild lost packets
+    (void)pkt;
+    (void)loss_seqs;
+    return false;
+}
+
+} // namespace srt

--- a/srtcore/fec_rs.h
+++ b/srtcore/fec_rs.h
@@ -1,0 +1,41 @@
+#ifndef INC_SRT_FEC_RS_H
+#define INC_SRT_FEC_RS_H
+
+#include <string>
+#include <vector>
+#include </usr/include/fec.h>
+
+#include "packetfilter_api.h"
+#include "packet.h"
+#include "utilities.h"
+#include "common.h"
+
+namespace srt {
+
+class FECReedSolomon : public SrtPacketFilterBase
+{
+    SrtFilterConfig cfg;
+    void* rs;
+    size_t data_shards;
+    size_t parity_shards;
+    std::vector<SrtPacket>& provided_packets;
+
+public:
+    FECReedSolomon(const SrtFilterInitializer& init,
+                   std::vector<SrtPacket>& provided,
+                   const std::string& confstr);
+    virtual ~FECReedSolomon();
+
+    static const size_t EXTRA_SIZE = 0;
+    static const char defaultConfig[];
+    static bool verifyConfig(const SrtFilterConfig& cfg, std::string& w_error);
+
+    virtual bool packControlPacket(SrtPacket& rpkt, int32_t seq) ATR_OVERRIDE;
+    virtual void feedSource(CPacket& pkt) ATR_OVERRIDE;
+    virtual bool receive(const CPacket& pkt, loss_seqs_t& loss_seqs) ATR_OVERRIDE;
+    virtual SRT_ARQLevel arqLevel() ATR_OVERRIDE { return SRT_ARQ_ONREQ; }
+};
+
+} // namespace srt
+
+#endif

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -12,6 +12,7 @@ core.cpp
 crypto.cpp
 epoll.cpp
 fec.cpp
+fec_rs.cpp
 handshake.cpp
 list.cpp
 logger_default.cpp
@@ -80,6 +81,7 @@ threadname.h
 tsbpd_time.h
 utilities.h
 window.h
+fec_rs.h
 
 PRIVATE HEADERS - ENABLE_BONDING
 group.h

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -314,6 +314,8 @@ PacketFilter::Internal::Internal()
 
     m_filters["fec"] = new PacketFilter::Creator<FECFilterBuiltin>;
     m_builtin_filters.insert("fec");
+    m_filters["rsfec"] = new PacketFilter::Creator<FECReedSolomon>;
+    m_builtin_filters.insert("rsfec");
 }
 
 bool PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::string& confstr)

--- a/srtcore/packetfilter_builtin.h
+++ b/srtcore/packetfilter_builtin.h
@@ -12,7 +12,8 @@
 #ifndef INC_SRT_PACKETFILTER_BUILTIN_H
 #define INC_SRT_PACKETFILTER_BUILTIN_H
 
-// Integration header
+// Integration headers
 #include "fec.h"
+#include "fec_rs.h"
 
 #endif


### PR DESCRIPTION
## Summary
- add new FECReedSolomon packet filter skeleton based on libfec
- expose new builtin filter `rsfec`
- register the filter and update build file lists

## Testing
- `cmake -S . -B build -DENABLE_UNITTESTS=OFF -DENABLE_APPS=OFF -DENABLE_TESTING=OFF`
- `cmake --build build -j4`

------
https://chatgpt.com/codex/tasks/task_e_6852381a55108323b80a3a8095a4c0d0